### PR TITLE
Modified the ramsete command

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -100,18 +100,10 @@ public class RobotContainer {
                 // Pass config
                 config);
 
-        RamseteCommandMerge ramseteCommand = new RamseteCommandMerge(exampleTrajectory, m_robotDrive::getPose,
-                new RamseteController(Constants.kRamseteB, Constants.kRamseteZeta), Constants.kDriveKinematics,
-                // RamseteCommand passes velocitires to the callback
-                m_robotDrive::tankDriveVelocities, m_robotDrive);
+        RamseteCommandMerge ramseteCommand = new RamseteCommandMerge(exampleTrajectory);
 
         // Run path following command, then stop at the end.
-        return ramseteCommand.andThen(() -> m_robotDrive.tankDriveVelocities(0, 0));
-        /**
-         * new SimpleMotorFeedforward(DriveConstants.ksVolts,
-         * DriveConstants.kvVoltSecondsPerMeter,
-         * DriveConstants.kaVoltSecondsSquaredPerMeter),
-         */
+        return ramseteCommand.andThen(() -> m_robotDrive.tankDriveVelocities(0, 0, 0, 0));
 
     }
 

--- a/src/main/java/frc/robot/commands/RamseteCommandMerge.java
+++ b/src/main/java/frc/robot/commands/RamseteCommandMerge.java
@@ -7,14 +7,9 @@
 
 package frc.robot.commands;
 
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
-
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.controller.PIDController;
 import edu.wpi.first.wpilibj.controller.RamseteController;
 import edu.wpi.first.wpilibj.controller.SimpleMotorFeedforward;
-import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.wpilibj.kinematics.DifferentialDriveWheelSpeeds;
@@ -22,7 +17,6 @@ import edu.wpi.first.wpilibj.trajectory.Trajectory;
 
 import static edu.wpi.first.wpilibj.util.ErrorMessages.requireNonNullParam;
 
-// ADDED IN
 import frc.robot.subsystems.DriveSubsystem;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;
@@ -30,127 +24,73 @@ import frc.robot.Constants;
 /**
  * This command is a modified version of the RamseteCommand from WpiLib.
  * 
- * 
- * 
  * A command that uses a RAMSETE controller ({@link RamseteController}) to follow a trajectory
  * {@link Trajectory} with a differential drive.
  *
- * <p>The command handles trajectory-following, PID calculations, and feedforwards internally.  This
+ * <p>The command handles trajectory-following, and feedforwards internally.  This
  * is intended to be a more-or-less "complete solution" that can be used by teams without a great
  * deal of controls expertise.
  *
  * <p>Advanced teams seeking more flexibility (for example, those who wish to use the onboard
  * PID functionality of a "smart" motor controller) may use the secondary constructor that omits
- * the PID and feedforward functionality, returning only the raw wheel speeds from the RAMSETE
- * controller.
+ * the PID returning only the raw wheel speeds from the RAMSETE controller.
  */
 @SuppressWarnings("PMD.TooManyFields")
 public class RamseteCommandMerge extends CommandBase {
     private final Timer m_timer = new Timer();
-    private final boolean m_usePID;
     private final Trajectory m_trajectory;
-    private final Supplier<Pose2d> m_pose;
     private final RamseteController m_follower;
     private final SimpleMotorFeedforward m_feedforward;
     private final DifferentialDriveKinematics m_kinematics;
-    private final Supplier<DifferentialDriveWheelSpeeds> m_speeds;
-    private final PIDController m_leftController;
-    private final PIDController m_rightController;
-    private final BiConsumer<Double, Double> m_output;
     private DifferentialDriveWheelSpeeds m_prevSpeeds;
     private double m_prevTime;
+    private final DriveSubsystem m_driveSubsystem;
+    private final double m_endEarly;
 
-    // ADDED IN
-    private final DriveSubsystem driveSubsystem;
 
     /**
      * Constructs a new RamseteCommand that, when executed, will follow the provided trajectory.
-     * PID control and feedforward are handled internally, and outputs are scaled -12 to 12
-     * representing units of volts.
-     *
-     * <p>Note: The controller will *not* set the outputVolts to zero upon completion of the path -
-     * this
-     * is left to the user, since it is not appropriate for paths with nonstationary endstates.
+     * Performs no PID control and calculates feedforwards; outputs are the raw wheel speeds
+     * from the RAMSETE controller and the feedforwards. It will follow the full trajectory
      *
      * @param trajectory            The trajectory to follow.
-     * @param pose                A function that supplies the robot pose - use one of
-     *                        the odometry classes to provide this.
-     * @param controller      The RAMSETE controller used to follow the trajectory.
-     * @param feedforward     The feedforward to use for the drive.
-     * @param kinematics      The kinematics for the robot drivetrain.
-     * @param wheelSpeeds     A function that supplies the speeds of the left and
-     *                        right sides of the robot drive.
-     * @param leftController  The PIDController for the left side of the robot drive.
-     * @param rightController The PIDController for the right side of the robot drive.
-     * @param outputVolts     A function that consumes the computed left and right
-     *                        outputs (in volts) for the robot drive.
-     * @param requirements    The subsystems to require.
      */
-  // @SuppressWarnings("PMD.ExcessiveParameterList")
-  // public RamseteCommandMerge(Trajectory trajectory,
-  //                       Supplier<Pose2d> pose,
-  //                       RamseteController controller,
-  //                       SimpleMotorFeedforward feedforward,
-  //                       DifferentialDriveKinematics kinematics,
-  //                       Supplier<DifferentialDriveWheelSpeeds> wheelSpeeds,
-  //                       PIDController leftController,
-  //                       PIDController rightController,
-  //                       BiConsumer<Double, Double> outputVolts,
-  //                       DriveSubsystem subsystem) {
-  //   m_trajectory = requireNonNullParam(trajectory, "trajectory", "RamseteCommand");
-  //   m_pose = requireNonNullParam(pose, "pose", "RamseteCommand");
-  //   m_follower = requireNonNullParam(controller, "controller", "RamseteCommand");
-  //   m_feedforward = feedforward;
-  //   m_kinematics = requireNonNullParam(kinematics, "kinematics", "RamseteCommand");
-  //   m_speeds = requireNonNullParam(wheelSpeeds, "wheelSpeeds", "RamseteCommand");
-  //   m_leftController = requireNonNullParam(leftController, "leftController", "RamseteCommand");
-  //   m_rightController = requireNonNullParam(rightController, "rightController", "RamseteCommand");
-  //   m_output = requireNonNullParam(outputVolts, "outputVolts", "RamseteCommand");
-
-  //   m_usePID = true;
-
-
-  //   addRequirements(subsystem);
-  // }
-
-  /**
-   * Constructs a new RamseteCommand that, when executed, will follow the provided trajectory.
-   * Performs no PID control and calculates no feedforwards; outputs are the raw wheel speeds
-   * from the RAMSETE controller, and will need to be converted into a usable form by the user.
-   *
-   * @param trajectory            The trajectory to follow.
-   * @param pose                  A function that supplies the robot pose - use one of
-   *                              the odometry classes to provide this.
-   * @param follower              The RAMSETE follower used to follow the trajectory.
-   * @param kinematics            The kinematics for the robot drivetrain.
-   * @param outputMetersPerSecond A function that consumes the computed left and right
-   *                              wheel speeds.
-   * @param requirements          The subsystems to require.
-   */
-   public RamseteCommandMerge(Trajectory trajectory,
-                        Supplier<Pose2d> pose,
-                        RamseteController follower,
-                        DifferentialDriveKinematics kinematics,
-                        BiConsumer<Double, Double> outputMetersPerSecond,
-                        DriveSubsystem subsystem) {
+    public RamseteCommandMerge(Trajectory trajectory) {
         m_trajectory = requireNonNullParam(trajectory, "trajectory", "RamseteCommand");
-        m_pose = requireNonNullParam(pose, "pose", "RamseteCommand");
-        m_follower = requireNonNullParam(follower, "follower", "RamseteCommand");
-        m_kinematics = requireNonNullParam(kinematics, "kinematics", "RamseteCommand");
-        m_output = requireNonNullParam(outputMetersPerSecond, "output", "RamseteCommand");
 
-        // Changed feedforward to look in constants file
-        m_feedforward = new SimpleMotorFeedforward(Constants.ksVolts, Constants.kvVoltSecondsPerMeter, Constants.kaVoltSecondsSquaredPerMeter);;
-        m_speeds = null;
-        m_leftController = null;
-        m_rightController = null;
+        m_driveSubsystem = DriveSubsystem.getInstance();
+        m_follower = new RamseteController(Constants.kRamseteB, Constants.kRamseteZeta);
+        m_kinematics = Constants.kDriveKinematics;
 
-        m_usePID = false;
+        m_feedforward = new SimpleMotorFeedforward(Constants.ksVolts, Constants.kvVoltSecondsPerMeter, Constants.kaVoltSecondsSquaredPerMeter);
 
-        // ADDED IN
-        driveSubsystem = subsystem;
+        m_endEarly = 1.0;
 
-        addRequirements(subsystem);
+        addRequirements(m_driveSubsystem);
+    }
+
+    /**
+     * Constructs a new RamseteCommand that, when executed, will follow the provided trajectory.
+     * Performs no PID control and calculates feedforwards; outputs are the raw wheel speeds
+     * from the RAMSETE controller and the feedforwards. It can end early based on parameters.
+     *
+     * @param trajectory            The trajectory to follow.
+     * @param endEarly          This double can allow the Ramsete Command to end the trajectory early. 
+     *                          The idea being that vision can calculate a new updated trajectory half way
+     *                          through which is more accurate.
+     */
+    public RamseteCommandMerge(Trajectory trajectory, double endEarly) {
+        m_trajectory = requireNonNullParam(trajectory, "trajectory", "RamseteCommand");
+
+        m_driveSubsystem = DriveSubsystem.getInstance();
+        m_follower = new RamseteController(Constants.kRamseteB, Constants.kRamseteZeta);
+        m_kinematics = Constants.kDriveKinematics;
+
+        m_feedforward = new SimpleMotorFeedforward(Constants.ksVolts, Constants.kvVoltSecondsPerMeter, Constants.kaVoltSecondsSquaredPerMeter);
+
+        m_endEarly = endEarly;
+        
+        addRequirements(m_driveSubsystem);
     }
 
     @Override
@@ -164,10 +104,6 @@ public class RamseteCommandMerge extends CommandBase {
                                 * initialState.velocityMetersPerSecond));
         m_timer.reset();
         m_timer.start();
-        if (m_usePID) {
-            m_leftController.reset();
-            m_rightController.reset();
-        }
     }
 
     @Override
@@ -176,47 +112,19 @@ public class RamseteCommandMerge extends CommandBase {
         double dt = curTime - m_prevTime;
 
         var targetWheelSpeeds = m_kinematics.toWheelSpeeds(
-                m_follower.calculate(m_pose.get(), m_trajectory.sample(curTime)));
+                m_follower.calculate(m_driveSubsystem.getPose(), m_trajectory.sample(curTime)));
 
         var leftSpeedSetpoint = targetWheelSpeeds.leftMetersPerSecond;
         var rightSpeedSetpoint = targetWheelSpeeds.rightMetersPerSecond;
-
-        double leftOutput;
-        double rightOutput;
-
-        if (m_usePID) {
-            double leftFeedforward =
-                    m_feedforward.calculate(leftSpeedSetpoint,
-                            (leftSpeedSetpoint - m_prevSpeeds.leftMetersPerSecond) / dt);
-
-            double rightFeedforward =
-                    m_feedforward.calculate(rightSpeedSetpoint,
-                            (rightSpeedSetpoint - m_prevSpeeds.rightMetersPerSecond) / dt);
-
-            leftOutput = leftFeedforward
-                    + m_leftController.calculate(m_speeds.get().leftMetersPerSecond,
-                    leftSpeedSetpoint);
-
-            rightOutput = rightFeedforward
-                    + m_rightController.calculate(m_speeds.get().rightMetersPerSecond,
-                    rightSpeedSetpoint);
-        } else {
-            leftOutput = leftSpeedSetpoint;
-            rightOutput = rightSpeedSetpoint;
-        }
-
-        // ADDED IN TO RUN FEEDFORWARDS FOR TALONS
+        
         double leftFeedforward =
                     m_feedforward.calculate(leftSpeedSetpoint,
                             (leftSpeedSetpoint - m_prevSpeeds.leftMetersPerSecond) / dt);
-            double rightFeedforward =
-                    m_feedforward.calculate(rightSpeedSetpoint,
-                            (rightSpeedSetpoint - m_prevSpeeds.rightMetersPerSecond) / dt);
-        driveSubsystem.setFeedForwards(leftFeedforward, rightFeedforward);
+        double rightFeedforward =
+                m_feedforward.calculate(rightSpeedSetpoint,
+                        (rightSpeedSetpoint - m_prevSpeeds.rightMetersPerSecond) / dt);
 
-
-
-        m_output.accept(leftOutput, rightOutput);
+        m_driveSubsystem.tankDriveVelocities(leftSpeedSetpoint, rightSpeedSetpoint, leftFeedforward, rightFeedforward);
 
         m_prevTime = curTime;
         m_prevSpeeds = targetWheelSpeeds;
@@ -229,6 +137,6 @@ public class RamseteCommandMerge extends CommandBase {
 
     @Override
     public boolean isFinished() {
-        return m_timer.hasElapsed(m_trajectory.getTotalTimeSeconds());
+        return m_timer.hasElapsed(m_trajectory.getTotalTimeSeconds() * m_endEarly);
     }
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -42,8 +42,6 @@ public class DriveSubsystem extends SubsystemBase {
     private WPI_VictorSPX leftSlave, rightSlave;
     private final int kPIDLoopIdx = 0;
     private final int kTimeoutMs = 1000;
-    private double leftFeedforward;
-    private double rightFeedforward;
 
     // Odometry class for tracking robot pose
     private final DifferentialDriveOdometry m_odometry;
@@ -52,6 +50,9 @@ public class DriveSubsystem extends SubsystemBase {
     // Pigeon Specific
     private PigeonIMU pigeon;
     private PigeonIMU.FusionStatus fusionStatus;
+
+    // DriveBase2020 is a singleton class as it represents a physical subsystem
+    private static DriveSubsystem currentInstance;
 
     /**
      * Creates a new DriveSubsystem.
@@ -100,6 +101,20 @@ public class DriveSubsystem extends SubsystemBase {
     public void followMotors() {
         leftSlave.follow(leftMaster);
         rightSlave.follow(rightMaster);
+    }
+
+    /**
+     * Initialize the current DriveBase instance
+     */
+    public static void init() {
+        if (currentInstance == null) {
+            currentInstance = new DriveSubsystem();
+        }
+    }
+
+    public static DriveSubsystem getInstance() {
+        init();
+        return currentInstance;
     }
 
     @Override
@@ -180,18 +195,6 @@ public class DriveSubsystem extends SubsystemBase {
     }
 
     /**
-     * Set the feedforward values to be used by tankDriveVelocities
-     * 
-     * @param setLeftFeedforward set left feedforward
-     * @param setRightFeedforward set right feedforward
-     */
-    public void setFeedForwards(double setLeftFeedforward, double setRightFeedforward) {
-        leftFeedforward = setLeftFeedforward;
-        rightFeedforward = setRightFeedforward;
-    }
-
-
-    /**
      * Controls the left and right sides of the drive directly with velocities.
      *
      * REQUIRED FOR RAMSETE COMMAND
@@ -199,7 +202,7 @@ public class DriveSubsystem extends SubsystemBase {
      * @param leftVolts the commanded left output
      * @param rightVolts the commanded right output
      */
-    public void tankDriveVelocities(double leftVelocity, double rightVelocity) {
+    public void tankDriveVelocities(double leftVelocity, double rightVelocity, double leftFeedforward, double rightFeedforward) {
         leftMaster.set(ControlMode.Velocity, leftVelocity, DemandType.ArbitraryFeedForward,
                 leftFeedforward / 12.0);
         rightMaster.set(ControlMode.Velocity, -rightVelocity, DemandType.ArbitraryFeedForward,


### PR DESCRIPTION
The RamseteCommand needed to be modified in order to use the secondary constructor ideas with the code to update the feed forward on every new velocity calculation.

Simplified constructor, making the command get constants directly from the constants file instead of through the constructor. Same thing with the supplier and consumer. This is to de-clutter the RobotContainer, instead of needing to feed all these things into every new RamseteCommand(params) all the RamseteCommandMerge needs is a trajectory.

Also added in the functionality to end the trajectory early if desired.